### PR TITLE
Pass className prop to Input component's children

### DIFF
--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -220,6 +220,7 @@ export default class Input extends Component {
     const inputProps = {
       ...rest,
       id,
+      className,
       ref: this.ref,
       size,
       value: this.state.value,

--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -196,7 +196,6 @@ export default class Input extends Component {
 
   render() {
     const {
-      className,
       style,
       minRows,
       maxRows,
@@ -220,7 +219,6 @@ export default class Input extends Component {
     const inputProps = {
       ...rest,
       id,
-      className,
       ref: this.ref,
       size,
       value: this.state.value,


### PR DESCRIPTION
Necessary for getting `styled-components` to pass down class names to underlying components.