### PR TITLE
Add vertical stacking to button group

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -119,12 +119,37 @@ Button.defaultProps = {
   transparent: false,
 };
 
+const verticalCss = ({ sizes, vertical }) => {
+  const maybeNumber = parseInt(vertical, 10);
+  const fallback = sizes[vertical] || sizes.sm;
+  const breakpoint = Number.isInteger(maybeNumber) ? `${maybeNumber}px` : `${fallback}px`;
+
+  return css`
+    @media (max-width: ${breakpoint}) {
+      flex-direction: column;
+
+      & > *:not(:first-child) {
+        margin: 1rem 0 0;
+      }
+    }
+  `;
+};
+
 Button.Group = createComponent({
   name: 'ButtonGroup',
-  style: css`
+  style: ({
+    vertical = false,
+    theme: {
+      grid: { sizes },
+    },
+  }) => css`
+    display: flex;
+
     & > *:not(:first-child) {
       margin-left: 1rem;
     }
+
+    ${vertical && verticalCss({ sizes, vertical })}
   `,
 });
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css, keyframes } from 'styled-components';
-import { space } from 'styled-system';
+import { space, flex } from 'styled-system';
 import { lighten } from 'polished';
 import { getComponentVariant, createComponent } from '../utils';
 
@@ -144,6 +144,8 @@ Button.Group = createComponent({
     },
   }) => css`
     display: flex;
+    justify-content: center;
+    ${flex}
 
     & > *:not(:first-child) {
       margin-left: 1rem;

--- a/src/Button/Button.mdx
+++ b/src/Button/Button.mdx
@@ -34,6 +34,16 @@ Button groups provide an easy way to horizontally layout a row of buttons.
   </Button.Group>
 </Playground>
 
+### Vertical Layout
+Use the `vertical` prop to pass a predefined or custom breakpoint size.
+<Playground>
+  <Button.Group vertical="lg">
+    <Button>One</Button>
+    <Button>Two</Button>
+    <Button outline>Three</Button>
+  </Button.Group>
+</Playground>
+
 ## Variants
 
 Buttons can come in several different shapes and colors

--- a/src/theme.js
+++ b/src/theme.js
@@ -68,7 +68,7 @@ export default (overrides = {}) => {
     xl: 16,
   };
 
-  const breakpoints = [368, 768, 1024, 1440];
+  const breakpoints = [480, 768, 1024, 1440];
 
   const grid = {
     containerMaxWidth: 1000,


### PR DESCRIPTION
> ### Summary
Adds the ability for button groups to layout their children in a vertical column at predefined or custom breakpoints.

**Example usage:**
```jsx
<Button.Group vertical="768" />
<Button.Group vertical={576} />
<Button.Group vertical /> //=> defaults to "sm" (768px)
<Button.Group vertical="lg" /> //=> any predefined breakpoint in `theme.grid.sizes`
```