### PR TITLE
fix(RadioGroup): don't loop state updates

### DIFF
--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -76,20 +76,22 @@ export default class Checkbox extends React.Component {
     disabled: false,
   };
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.value && props.value !== state.value) {
+      return {
+        value: props.value,
+      };
+    }
+
+    return null;
+  }
+
   state = {
     value: this.props.value,
   };
 
   get checked() {
     return this.state.value === this.props.valueTrue;
-  }
-
-  componentDidUpdate() {
-    if (this.props.value !== undefined && this.state.value !== this.props.value) {
-      this.setState({
-        value: this.props.value,
-      });
-    }
   }
 
   handleChange = () => {

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -77,7 +77,7 @@ export default class Checkbox extends React.Component {
   };
 
   static getDerivedStateFromProps(props, state) {
-    if (props.value && props.value !== state.value) {
+    if (props.value !== undefined && props.value !== state.value) {
       return {
         value: props.value,
       };

--- a/src/Form/Checkbox.mdx
+++ b/src/Form/Checkbox.mdx
@@ -22,7 +22,7 @@ Form Checkbox component. Different sizes are available.
   <Checkbox id="checkbox" name="checkbox" />
 </Playground>
 
-### Checkbox Group
+### Checkbox Group vertical
 <Playground>
   {() => {
     const checkboxValues = [
@@ -37,19 +37,41 @@ Form Checkbox component. Different sizes are available.
         label: 'Checkbox 2',
       },
     ];
+
     return (
       <div>
-        <h3>Vertical</h3>
         <CheckboxGroup name="checkboxes" id="checkboxes" choices={checkboxValues} />
+      </div>
+    )
+  }}
+</Playground>
 
-        <h3>Horizontal</h3>
+### Checkbox Group horizontal
+<Playground>
+  {() => {
+    const checkboxValues = [
+      {
+        id: 1,
+        value: 'test',
+        label: 'Checkbox 1',
+      },
+      {
+        id: 2,
+        value: 'test2',
+        label: 'Checkbox 2',
+      },
+    ];
+
+    return (
+      <div>
         <CheckboxGroup horizontal name="checkboxes" id="checkboxes" choices={checkboxValues} />
       </div>
     )
   }}
 </Playground>
 
-### Checkbox colors
+
+### Checkbox Group exclusivity
 <Playground>
   {() => {
     const checkboxValues = [
@@ -63,11 +85,29 @@ Form Checkbox component. Different sizes are available.
         value: 'test2',
         label: 'Checkbox 2',
       },
+      {
+        id: 3,
+        value: 'neither',
+        label: 'Neither',
+        exclusive: true,
+      },
     ];
+
     return (
-      <React.Fragment>
-        <Checkbox id="checkbox" name="checkbox" color="green" />
-      </React.Fragment>
+      <div>
+        <CheckboxGroup horizontal name="checkboxes" id="checkboxes" choices={checkboxValues} />
+      </div>
     )
   }}
+</Playground>
+
+
+### Checkbox colors
+<Playground>
+  {() => (
+    <React.Fragment>
+      <Checkbox id="checkbox" name="checkbox" colorOn="green" colorOff="red" />
+      <Checkbox id="checkbox" name="checkbox" colorOn="green" colorOff="red" value={true} />
+    </React.Fragment>
+  )}
 </Playground>

--- a/src/Form/Radio.mdx
+++ b/src/Form/Radio.mdx
@@ -80,7 +80,7 @@ Form Radio component. Different sizes are available.
       },
     ];
     return (
-      <RadioGroup color="green" name="radio" id="radio" choices={radioValues} />
+      <RadioGroup colorOn="green" colorOff="red" name="radio" id="radio" choices={radioValues} value='radio2' />
     )
   }}
 </Playground>

--- a/src/Form/RadioGroup.js
+++ b/src/Form/RadioGroup.js
@@ -17,7 +17,8 @@ export default class RadioGroup extends Component {
     name: PropTypes.string,
     onChange: PropTypes.func,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    color: PropTypes.string,
+    colorOn: PropTypes.string,
+    colorOff: PropTypes.string,
     size: PropTypes.string,
     choices: PropTypes.arrayOf(
       PropTypes.shape({
@@ -31,18 +32,17 @@ export default class RadioGroup extends Component {
   static defaultProps = {
     choices: [],
     onChange() {},
-    color: 'primary',
     size: 'md',
   };
 
   static getDerivedStateFromProps(props, state) {
-    if (props.value === state.value) {
-      return null;
+    if (props.value && props.value !== state.value) {
+      return {
+        value: props.value,
+      };
     }
 
-    return {
-      value: props.value,
-    }
+    return null;
   }
 
   state = {
@@ -59,7 +59,7 @@ export default class RadioGroup extends Component {
   };
 
   render() {
-    const { choices, error, horizontal, label, name, color, size } = this.props;
+    const { choices, error, horizontal, label, name, colorOn, colorOff, size } = this.props;
 
     return (
       <StyledRadioGroup>
@@ -78,7 +78,8 @@ export default class RadioGroup extends Component {
                   name={key}
                   horizontal={horizontal}
                   size={size}
-                  color={color}
+                  colorOn={colorOn}
+                  colorOff={colorOff}
                   label={choiceLabel}
                   value={this.state.value}
                   valueTrue={value}

--- a/src/Form/RadioGroup.js
+++ b/src/Form/RadioGroup.js
@@ -35,15 +35,19 @@ export default class RadioGroup extends Component {
     size: 'md',
   };
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.value === state.value) {
+      return null;
+    }
+
+    return {
+      value: props.value,
+    }
+  }
+
   state = {
     value: this.props.value || null,
   };
-
-  componentDidUpdate() {
-    if (this.props.value !== undefined && this.props.value !== this.state.value) {
-      this.handleChange(null, this.props.value);
-    }
-  }
 
   handleChange = (field, value) => {
     // Bail out if value is the same

--- a/src/Form/RadioGroup.js
+++ b/src/Form/RadioGroup.js
@@ -36,7 +36,7 @@ export default class RadioGroup extends Component {
   };
 
   static getDerivedStateFromProps(props, state) {
-    if (props.value && props.value !== state.value) {
+    if (props.value !== undefined && props.value !== state.value) {
       return {
         value: props.value,
       };


### PR DESCRIPTION
looks like this was the issue here: https://app.asana.com/0/821652619613450/929543341861746/f

`componentDidUpdate` gets called after `handleChange` on user input - this was calling `handleChange` again with the old value (because `this.props.value` isn't updated until `Formbot.setState` is called and propagated back down)