### PR TITLE
Don't use dangerous HTML in Linkify

### DIFF
--- a/src/Linkify/Linkify.js
+++ b/src/Linkify/Linkify.js
@@ -2,45 +2,48 @@ import React from 'react';
 
 const URL_REGEX = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi;
 
-const detectLinks = ({ children, linkStyle = {} }) =>
+const Link = ({ href, linkStyle }) => (
+  <a
+    target="_blank"
+    rel="noopener noreferrer"
+    style={{
+      color: 'inherit',
+      textDecoration: 'underline',
+      ...linkStyle,
+    }}
+    href={href}>
+    {href}
+  </a>
+);
+
+const linkify = ({ children, linkStyle = {} }) =>
   React.Children.map(children, child => {
     if (!child) return null;
 
     if (typeof child === 'string') {
-      const words = child.split(' ');
-      return words.map((word, index) => {
-        const isLastWord = words.length - 1 === index;
+      const matches = child.match(URL_REGEX);
 
-        if (URL_REGEX.test(word)) {
-          return (
-            <>
-              <a
-                key={word}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  color: 'inherit',
-                  textDecoration: 'underline',
-                  ...linkStyle,
-                }}
-                href={word}>
-                {word}
-              </a>
+      if (!matches) {
+        return child;
+      }
 
-              {isLastWord ? '' : ' '}
-            </>
-          );
-        }
+      // Clone the string for manipulation
+      let string = `${child}`;
 
-        return isLastWord ? word : `${word} `;
-      });
+      // Run through the url matches to create our array of string parts and Link components
+      const stringParts = matches.reduce((parts, url) => {
+        const urlStartIndex = string.indexOf(url);
+        const partBeforeUrl = string.substring(0, urlStartIndex);
+        parts.push(partBeforeUrl, <Link href={url} linkStyle={linkStyle} />);
+        string = string.substring(urlStartIndex + url.length);
+        return parts;
+      }, []);
+
+      // Add any leftovers after the last url
+      return [...stringParts, string].filter(Boolean);
     }
 
-    if (React.isValidElement(child)) {
-      return detectLinks({ children: child.props.children, linkStyle });
-    }
-
-    return child;
+    return linkify({ children: child.props.children, linkStyle });
   });
 
-export default props => detectLinks(props);
+export default props => linkify(props);

--- a/src/Linkify/Linkify.js
+++ b/src/Linkify/Linkify.js
@@ -9,7 +9,7 @@ const detectLinks = ({ children, linkStyle = {} }) =>
     if (typeof child === 'string') {
       const words = child.split(' ');
       return words.map((word, index) => {
-        const isLastWord = words.length === index - 1;
+        const isLastWord = words.length - 1 === index;
 
         if (URL_REGEX.test(word)) {
           return (

--- a/src/Linkify/Linkify.js
+++ b/src/Linkify/Linkify.js
@@ -40,7 +40,7 @@ const linkify = ({ children, linkStyle = {} }) =>
       }, []);
 
       // Add any leftovers after the last url
-      return [...stringParts, string].filter(Boolean);
+      return [...stringParts, string];
     }
 
     return linkify({ children: child.props.children, linkStyle });

--- a/src/Linkify/Linkify.js
+++ b/src/Linkify/Linkify.js
@@ -8,9 +8,21 @@ const Container = styled.span`
   }
 `;
 
-const REGEX = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi;
+const escapeHtmlChars = (unsafe = '') =>
+  unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
 
-const parse = string => string.replace(REGEX, url => `<a target="_blank" href="${url}">${url}</a>`);
+const REGEX = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi;
+
+const parse = string =>
+  escapeHtmlChars(string).replace(
+    REGEX,
+    url => `<a target="_blank" rel="noopener noreferrer" href="${url}">${url}</a>`
+  );
 
 const Linkify = props => (
   <Container style={props.style || {}} dangerouslySetInnerHTML={{ __html: parse(props.children) }} />

--- a/src/Linkify/Linkify.mdx
+++ b/src/Linkify/Linkify.mdx
@@ -12,7 +12,15 @@ Automatically parse links contained in a body of text.
 
 ## Example
 <Playground>
-  <Linkify>
-    Checkout http://google.com. Another one that is not that great is http://bing.com.
-  </Linkify>
+  {() => {
+    const testEvaluatedUrl = 'https://www.facebook.com/heydoctor.co';
+    return (
+        <Linkify linkStyle={{ color: 'magenta' }}>
+          <div>
+            Checkout http://google.com. <span onmouseover="alert('yo')"
+            >Another</span> one that's not so great is http://bing.com. You could also checkout duckduckgo.com if you're into that whole privacy thing. <img src="fake.jpg" onError={() => {}} alt="hacker" /> Oh, and you should also check out https://heydoctor.co. <Linkify>I wonder if nested Linkify works {testEvaluatedUrl}</Linkify>
+          </div>
+        </Linkify>
+    )
+  }}
 </Playground>

--- a/src/Linkify/Linkify.mdx
+++ b/src/Linkify/Linkify.mdx
@@ -15,12 +15,12 @@ Automatically parse links contained in a body of text.
   {() => {
     const testEvaluatedUrl = 'https://www.facebook.com/heydoctor.co';
     return (
-        <Linkify linkStyle={{ color: 'magenta' }}>
-          <div>
-            Checkout http://google.com. <span onmouseover="alert('yo')"
-            >Another</span> one that's not so great is http://bing.com. You could also checkout duckduckgo.com if you're into that whole privacy thing. <img src="fake.jpg" onError={() => {}} alt="hacker" /> Oh, and you should also check out https://heydoctor.co. <Linkify>I wonder if nested Linkify works {testEvaluatedUrl}</Linkify>
-          </div>
-        </Linkify>
-    )
+      <Linkify linkStyle={{ color: 'magenta' }}>
+        <div>
+          Checkout http://google.com. <span onmouseover="alert('yo')"
+          >Another</span> one that's not so great is http://bing.com. You could also checkout duckduckgo.com if you're into that whole privacy thing. <img src="fake.jpg" onError={() => {}} alt="hacker" /> Oh, and you should also check out https://heydoctor.co. <Linkify>I wonder if nested Linkify works {testEvaluatedUrl}</Linkify>
+        </div>
+      </Linkify>
+    );
   }}
 </Playground>

--- a/src/Linkify/Linkify.spec.js
+++ b/src/Linkify/Linkify.spec.js
@@ -16,4 +16,12 @@ describe('Linkify', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  test('can receive linkStyle', () => {
+    const component = renderWithTheme(
+      <Linkify linkStyle={{ color: 'magenta' }}>Hello! https://google.com is a cool site.</Linkify>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/Linkify/Linkify.spec.js
+++ b/src/Linkify/Linkify.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { renderWithTheme } from '../../test/utils';
+import Linkify from './Linkify';
+
+describe('Linkify', () => {
+  test('converts links to anchor tags', () => {
+    const component = renderWithTheme(<Linkify>Hello! https://google.com is a cool site.</Linkify>);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('escapes HTML entities', () => {
+    const component = renderWithTheme(<Linkify>{`<span onmouseover=alert('XSS')></span>`}</Linkify>);
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/Linkify/Linkify.spec.js
+++ b/src/Linkify/Linkify.spec.js
@@ -10,7 +10,12 @@ describe('Linkify', () => {
   });
 
   test('escapes HTML entities', () => {
-    const component = renderWithTheme(<Linkify>{`<span onmouseover=alert('XSS')></span>`}</Linkify>);
+    const component = renderWithTheme(
+      <Linkify>
+        <img src="fake.jpg" onError={() => {}} alt="hacker" />
+        <span>heheh got hacked</span>
+      </Linkify>
+    );
 
     expect(component).toMatchSnapshot();
   });

--- a/src/Linkify/Linkify.spec.js
+++ b/src/Linkify/Linkify.spec.js
@@ -11,10 +11,7 @@ describe('Linkify', () => {
 
   test('escapes HTML entities', () => {
     const component = renderWithTheme(
-      <Linkify>
-        <img src="fake.jpg" onError={() => {}} alt="hacker" />
-        <span>heheh got hacked</span>
-      </Linkify>
+      <Linkify>{`<img src="fake.jpg" onError={() => {}} alt="hacker" /><span>heheh got hacked</span>`}</Linkify>
     );
 
     expect(component).toMatchSnapshot();

--- a/src/Linkify/__snapshots__/Linkify.spec.js.snap
+++ b/src/Linkify/__snapshots__/Linkify.spec.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Linkify can receive linkStyle 1`] = `
+Array [
+  "Hello! ",
+  <a
+    href="https://google.com"
+    rel="noopener noreferrer"
+    style={
+      Object {
+        "color": "magenta",
+        "textDecoration": "underline",
+      }
+    }
+    target="_blank"
+  >
+    https://google.com
+  </a>,
+  " is a cool site.",
+]
+`;
+
 exports[`Linkify converts links to anchor tags 1`] = `
 Array [
   "Hello! ",

--- a/src/Linkify/__snapshots__/Linkify.spec.js.snap
+++ b/src/Linkify/__snapshots__/Linkify.spec.js.snap
@@ -16,24 +16,8 @@ Array [
   >
     https://google.com
   </a>,
-  " ",
-  "is ",
-  "a ",
-  "cool ",
-  "site.",
+  " is a cool site.",
 ]
 `;
 
-exports[`Linkify escapes HTML entities 1`] = `
-Array [
-  "<img ",
-  "src=\\"fake.jpg\\" ",
-  "onError={() ",
-  "=> ",
-  "{}} ",
-  "alt=\\"hacker\\" ",
-  "/><span>heheh ",
-  "got ",
-  "hacked</span>",
-]
-`;
+exports[`Linkify escapes HTML entities 1`] = `"<img src=\\"fake.jpg\\" onError={() => {}} alt=\\"hacker\\" /><span>heheh got hacked</span>"`;

--- a/src/Linkify/__snapshots__/Linkify.spec.js.snap
+++ b/src/Linkify/__snapshots__/Linkify.spec.js.snap
@@ -20,14 +20,20 @@ Array [
   "is ",
   "a ",
   "cool ",
-  "site. ",
+  "site.",
 ]
 `;
 
 exports[`Linkify escapes HTML entities 1`] = `
 Array [
-  "heheh ",
+  "<img ",
+  "src=\\"fake.jpg\\" ",
+  "onError={() ",
+  "=> ",
+  "{}} ",
+  "alt=\\"hacker\\" ",
+  "/><span>heheh ",
   "got ",
-  "hacked ",
+  "hacked</span>",
 ]
 `;

--- a/src/Linkify/__snapshots__/Linkify.spec.js.snap
+++ b/src/Linkify/__snapshots__/Linkify.spec.js.snap
@@ -1,37 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Linkify converts links to anchor tags 1`] = `
-.c0 a {
-  color: inherit;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-<span
-  className="c0"
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "Hello! <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://google.com\\">https://google.com</a> is a cool site.",
+Array [
+  "Hello! ",
+  <a
+    href="https://google.com"
+    rel="noopener noreferrer"
+    style={
+      Object {
+        "color": "inherit",
+        "textDecoration": "underline",
+      }
     }
-  }
-  style={Object {}}
-/>
+    target="_blank"
+  >
+    https://google.com
+  </a>,
+  " ",
+  "is ",
+  "a ",
+  "cool ",
+  "site. ",
+]
 `;
 
 exports[`Linkify escapes HTML entities 1`] = `
-.c0 a {
-  color: inherit;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-<span
-  className="c0"
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "&lt;span onmouseover=alert(&#039;XSS&#039;)&gt;&lt;/span&gt;",
-    }
-  }
-  style={Object {}}
-/>
+Array [
+  "heheh ",
+  "got ",
+  "hacked ",
+]
 `;

--- a/src/Linkify/__snapshots__/Linkify.spec.js.snap
+++ b/src/Linkify/__snapshots__/Linkify.spec.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Linkify converts links to anchor tags 1`] = `
+.c0 a {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<span
+  className="c0"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "Hello! <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://google.com\\">https://google.com</a> is a cool site.",
+    }
+  }
+  style={Object {}}
+/>
+`;
+
+exports[`Linkify escapes HTML entities 1`] = `
+.c0 a {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<span
+  className="c0"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "&lt;span onmouseover=alert(&#039;XSS&#039;)&gt;&lt;/span&gt;",
+    }
+  }
+  style={Object {}}
+/>
+`;


### PR DESCRIPTION
> ### Summary
Fixed an issue with the `Linkify` component allowing execution of arbitrary HTML/JS that could be used for XSS attacks. 

Props to @kylealwyn for the actual implementation. 