### PR TITLE
Fix spinner color for outline buttons

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -14,7 +14,7 @@ const spinKeyframes = keyframes`
     transform: rotate(360deg);
 }`;
 
-const loadingCss = ({ height, fontColor }) => css`
+const loadingCss = ({ height, fontColor, outline, backgroundColor }) => css`
   color: transparent !important;
   pointer-events: none;
   position: relative;
@@ -24,7 +24,7 @@ const loadingCss = ({ height, fontColor }) => css`
   &::after {
     display: block;
     content: '';
-    border-color: ${fontColor};
+    border-color: ${outline ? backgroundColor : fontColor};
     animation: ${spinKeyframes} 820ms infinite linear;
     border-width: ${height * 0.05}px;
     border-style: solid;
@@ -80,7 +80,7 @@ const StyledButton = createComponent({
       border: ${transparent ? 'none' : `1px solid ${backgroundColor}`};
       transition: 175ms;
 
-      ${loading && loadingCss({ height, fontColor })};
+      ${loading && loadingCss({ height, fontColor, outline, backgroundColor })};
 
       &:hover {
         background: ${outline ? 'transparent' : lighten(0.05, backgroundColor)};

--- a/src/Button/Button.mdx
+++ b/src/Button/Button.mdx
@@ -3,8 +3,8 @@ name: Button
 menu: Core
 ---
 
-import { Playground, PropsTable } from 'docz'
-import Button from './Button'
+import { Playground, PropsTable } from 'docz';
+import Button from './Button';
 
 # Button
 
@@ -26,6 +26,7 @@ Custom button styles for actions in forms, dialogs, and more with support for mu
 ## Groups
 
 Button groups provide an easy way to horizontally layout a row of buttons.
+
 <Playground>
   <Button.Group>
     <Button>One</Button>
@@ -35,7 +36,9 @@ Button groups provide an easy way to horizontally layout a row of buttons.
 </Playground>
 
 ### Vertical Layout
+
 Use the `vertical` prop to pass a predefined or custom breakpoint size.
+
 <Playground>
   <Button.Group vertical="lg">
     <Button>One</Button>
@@ -88,5 +91,8 @@ Add the `disabled` prop for disabled button state style.
 Add the `loading` prop for loading button state style.
 
 <Playground>
-  <Button loading>I'm loading</Button>
+  <Button.Group>
+    <Button loading>I'm loading</Button>
+    <Button loading outline>I'm loading</Button>
+  </Button.Group>
 </Playground>


### PR DESCRIPTION
> ### Summary 
Fixed issue with buttons having both `outline` and `loading` props displaying a transparent spinner. 

<img width="769" alt="screen shot 2018-12-04 at 4 54 35 pm" src="https://user-images.githubusercontent.com/6404663/49482771-5e82c500-f7e5-11e8-81ad-343fe54231f4.png">
