### PR TITLE
Allow input to be a number

### DIFF
--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -54,7 +54,7 @@ const StyledTextArea = StyledInput.withComponent('textarea');
 
 export default class Input extends Component {
   static propTypes = {
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     disabled: PropTypes.bool,
     placeholder: PropTypes.string,
     multiline: PropTypes.bool,


### PR DESCRIPTION
Summary:
Allows the form input to accept a number without a warning