### PR TITLE
fix(Dropdown): Support for configuring dropdown offset

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -15,12 +15,12 @@ const DropdownTrigger = createComponent({
 
 const DropdownMenu = createComponent({
   name: 'DropdownMenu',
-  style: ({ width = 150, theme }) => css`
+  style: ({ width = 150, theme, border, radius }) => css`
     z-index: 10;
     position: absolute;
     background: white;
-    border-radius: ${theme.radius}px;
-    border: 1px solid #e4edf5;
+    border-radius: ${radius || theme.radius}px;
+    border: ${border ? 1px solid #e4edf5 : none};
     box-shadow: 0 0 3px 0 rgba(178, 194, 212, 0.3);
     min-width: 90px;
     width: ${width}px;
@@ -42,6 +42,7 @@ export default class Dropdown extends React.Component {
     placement: 'bottom-start',
     boundariesElement: 'window',
     on: 'click',
+    border: true,
   };
 
   triggerRef = React.createRef();
@@ -71,7 +72,7 @@ export default class Dropdown extends React.Component {
   }
 
   show = () => {
-    const { placement, boundariesElement } = this.props;
+    const { offset, placement, boundariesElement } = this.props;
 
     this.setState(
       {
@@ -82,7 +83,7 @@ export default class Dropdown extends React.Component {
           placement,
           modifiers: {
             offset: {
-              offset: '0, 10',
+              offset: offset || '0, 10',
             },
             flip: {
               behavior: ['left', 'bottom', 'top', 'right'],

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -15,13 +15,13 @@ const DropdownTrigger = createComponent({
 
 const DropdownMenu = createComponent({
   name: 'DropdownMenu',
-  style: ({ width = 150, theme, border, radius }) => css`
+  style: ({ width = 150, theme, border, radius, boxShadow }) => css`
     z-index: 10;
     position: absolute;
     background: white;
     border-radius: ${radius || theme.radius}px;
     border: ${border ? '1px solid #e4edf5' : 'none'};
-    box-shadow: 0 0 3px 0 rgba(178, 194, 212, 0.3);
+    box-shadow: ${boxShadow || '0 0 3px 0 rgba(178, 194, 212, 0.3)'};
     min-width: 90px;
     width: ${width}px;
   `,
@@ -136,7 +136,7 @@ export default class Dropdown extends React.Component {
   };
 
   render() {
-    const { width, trigger, render, children } = this.props;
+    const { width, border, boxShadow, radius, trigger, render, children } = this.props;
     const { isOpen } = this.state;
 
     const renderFn = render || children;
@@ -149,7 +149,7 @@ export default class Dropdown extends React.Component {
 
         <Portal>
           {isOpen && (
-            <DropdownMenu ref={this.menuRef} width={width}>
+            <DropdownMenu ref={this.menuRef} width={width} border={border} boxShadow={boxShadow} radius={radius}>
               {renderFn({
                 close: this.toggle,
               })}

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -22,7 +22,7 @@ const DropdownMenu = createComponent({
     border-radius: ${theme.radius}px;
     border: 1px solid #e4edf5;
     box-shadow: 0 0 3px 0 rgba(178, 194, 212, 0.3);
-    min-width: 150px;
+    min-width: 90px;
     width: ${width}px;
   `,
 });

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -15,14 +15,14 @@ const DropdownTrigger = createComponent({
 
 const DropdownMenu = createComponent({
   name: 'DropdownMenu',
-  style: ({ width = 150, theme, border, radius, boxShadow }) => css`
+  style: ({ width = 150, theme }) => css`
     z-index: 10;
     position: absolute;
     background: white;
-    border-radius: ${radius || theme.radius}px;
-    border: ${border ? '1px solid #e4edf5' : 'none'};
-    box-shadow: ${boxShadow || '0 0 3px 0 rgba(178, 194, 212, 0.3)'};
-    min-width: 90px;
+    border-radius: ${theme.radius}px;
+    border: 1px solid #e4edf5;
+    box-shadow: 0 0 3px 0 rgba(178, 194, 212, 0.3);
+    min-width: 150px;
     width: ${width}px;
   `,
 });
@@ -33,16 +33,17 @@ export default class Dropdown extends React.Component {
     render: PropTypes.func,
     autoclose: PropTypes.bool,
     placement: PropTypes.string,
+    offset: PropTypes.string,
     boundariesElement: PropTypes.string,
     on: PropTypes.string,
   };
 
   static defaultProps = {
     autoclose: true,
+    offset: '0, 10', 
     placement: 'bottom-start',
     boundariesElement: 'window',
     on: 'click',
-    border: true,
   };
 
   triggerRef = React.createRef();
@@ -72,7 +73,7 @@ export default class Dropdown extends React.Component {
   }
 
   show = () => {
-    const { offset = '0, 10', placement, boundariesElement } = this.props;
+    const { placement, boundariesElement } = this.props;
 
     this.setState(
       {
@@ -136,7 +137,7 @@ export default class Dropdown extends React.Component {
   };
 
   render() {
-    const { width, border, boxShadow, radius, trigger, render, children } = this.props;
+    const { width, trigger, render, children } = this.props;
     const { isOpen } = this.state;
 
     const renderFn = render || children;
@@ -149,7 +150,7 @@ export default class Dropdown extends React.Component {
 
         <Portal>
           {isOpen && (
-            <DropdownMenu ref={this.menuRef} width={width} border={border} boxShadow={boxShadow} radius={radius}>
+            <DropdownMenu ref={this.menuRef} width={width}>
               {renderFn({
                 close: this.toggle,
               })}

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -20,7 +20,7 @@ const DropdownMenu = createComponent({
     position: absolute;
     background: white;
     border-radius: ${radius || theme.radius}px;
-    border: ${border ? 1px solid #e4edf5 : none};
+    border: ${border ? '1px solid #e4edf5' : 'none'};
     box-shadow: 0 0 3px 0 rgba(178, 194, 212, 0.3);
     min-width: 90px;
     width: ${width}px;
@@ -72,7 +72,7 @@ export default class Dropdown extends React.Component {
   }
 
   show = () => {
-    const { offset, placement, boundariesElement } = this.props;
+    const { offset = '0, 10', placement, boundariesElement } = this.props;
 
     this.setState(
       {
@@ -83,7 +83,7 @@ export default class Dropdown extends React.Component {
           placement,
           modifiers: {
             offset: {
-              offset: offset || '0, 10',
+              offset,
             },
             flip: {
               behavior: ['left', 'bottom', 'top', 'right'],

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -75,7 +75,7 @@ export default class Dropdown extends React.Component {
   }
 
   show = () => {
-    const { placement, boundariesElement } = this.props;
+    const { placement, boundariesElement, offset } = this.props;
 
     this.setState(
       {

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -15,7 +15,7 @@ const DropdownTrigger = createComponent({
 
 const DropdownMenu = createComponent({
   name: 'DropdownMenu',
-  style: ({ width = 150, theme }) => css`
+  style: ({ width, theme }) => css`
     z-index: 10;
     position: absolute;
     background: white;
@@ -36,14 +36,16 @@ export default class Dropdown extends React.Component {
     offset: PropTypes.string,
     boundariesElement: PropTypes.string,
     on: PropTypes.string,
+    width: PropTypes.number,
   };
 
   static defaultProps = {
     autoclose: true,
-    offset: '0, 10', 
+    offset: '0, 10',
     placement: 'bottom-start',
     boundariesElement: 'window',
     on: 'click',
+    width: 150,
   };
 
   triggerRef = React.createRef();


### PR DESCRIPTION
The [redesigned EMR dashboard](https://app.asana.com/0/821652619613450/1104820821162262/f) requires the following properties of the dropdown component to be configurable: border-radius, border, offset.

Related CMS PR: https://github.com/sappira-inc/cms/pull/225

Tested locally via `yarn docs`
<img width="489" alt="image" src="https://user-images.githubusercontent.com/16051172/52827145-6c23b900-3078-11e9-98e1-bd7548c4f4d0.png">
